### PR TITLE
refactor tests to use snapshots

### DIFF
--- a/__tests__/__snapshots__/cli.spec.js.snap
+++ b/__tests__/__snapshots__/cli.spec.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLI qnm list should show all modules in node_modules directory 1`] = `
+"@scope/test
+└── 1.0.0
+
+another
+└── 1.0.0
+
+test
+├── 1.0.0
+└─┬ another
+  └── 1.0.0
+
+"
+`;
+
+exports[`CLI qnm list should show modules mentioned in package.json 1`] = `
+"dependency1
+└── 1.0.0
+
+dependency2
+└── 1.0.0
+
+devDependency1
+└── 1.0.0
+
+devDependency2
+└── 1.0.0
+
+"
+`;
+
+exports[`CLI qnm with no arguments should add dependents information when using thw --why option 1`] = `
+"test
+└── 1.0.0 (devDependencies, npm install test)
+
+"
+`;
+
+exports[`CLI qnm with no arguments should add dependents information when using thw -w option 1`] = `
+"test
+└── 1.0.0 (devDependencies, npm install test)
+
+"
+`;
+
+exports[`CLI qnm with no arguments should show get matchs when using the match command 1`] = `
+"test
+└── 1.0.0
+
+"
+`;
+
+exports[`CLI qnm with no arguments should show the version on a single module when called with a string 1`] = `
+"test
+└── 1.0.0
+
+"
+`;

--- a/__tests__/actions/__snapshots__/get.spec.js.snap
+++ b/__tests__/actions/__snapshots__/get.spec.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`get should get the version of a module in depth 1`] = `
+"[4mtest[24m
+└─┬ [90manother[39m
+  └── 1.0.0
+"
+`;
+
+exports[`get should get the version of a single module 1`] = `
+"[4mtest[24m
+└── 1.0.0
+"
+`;
+
+exports[`get should get the version of a single module when in a scoped package 1`] = `
+"[4m@scope/test[24m
+└── 1.0.0
+"
+`;
+
+exports[`get should get the version of a single module when not starting at the root 1`] = `
+"[4mtest[24m
+└── 1.0.0
+"
+`;
+
+exports[`get should print versions in three levels deep including ancestors 1`] = `
+"[4mdep-of-dep-of-dep[24m
+└─┬ [90mdep[39m
+  └─┬ [90mdep-of-dep[39m
+    └── 1.0.0
+"
+`;
+
+exports[`get should show a message when no module has found 1`] = `"Could not find any module by the name \\"not-exist\\"."`;
+
+exports[`get should suggest an alternative when no module has found and there is an alternative with an edit distance smaller than 2 1`] = `"Could not find any module by the name \\"dest\\". Did you mean \\"[1mt[22mest\\"?"`;
+
+exports[`get should suggest an alternative when no module has found and there is an alternative with an edit distance smaller than 2 2`] = `"Could not find any module by the name \\"dest\\". Did you mean \\"[1mt[22mest\\"?"`;

--- a/__tests__/actions/__snapshots__/list.spec.js.snap
+++ b/__tests__/actions/__snapshots__/list.spec.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`list should list the versions of mixed modules 1`] = `
+"[4m@scope/test[24m
+└── 1.0.0
+
+[4manother[24m
+└── 1.0.0
+
+[4mtest[24m
+├── 1.0.0
+└─┬ [90manother[39m
+  └── 1.0.0
+"
+`;

--- a/__tests__/actions/__snapshots__/match.spec.js.snap
+++ b/__tests__/actions/__snapshots__/match.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`match should print the matched modules according to passed string 1`] = `
+"[4m[35manot[39mher[24m
+└── 1.0.0
+"
+`;
+
+exports[`match should show a message when no module has matched the provided string 1`] = `"Could not find any module that matches \\"bla\\""`;

--- a/__tests__/actions/get.spec.js
+++ b/__tests__/actions/get.spec.js
@@ -1,4 +1,3 @@
-const chalk = require('chalk');
 const getAction = require('../../src/actions/get');
 const { resolveWorkspace } = require('../utils');
 
@@ -7,8 +6,7 @@ describe('get', () => {
     const workspace = resolveWorkspace('single-module');
     const output = getAction(workspace, 'test');
 
-    expect(output).toMatch(`${chalk.underline('test')}
-└── 1.0.0`);
+    expect(output).toMatchSnapshot();
   });
 
   it('should show a message when no module has found', () => {
@@ -16,9 +14,7 @@ describe('get', () => {
     try {
       getAction(workspace, 'not-exist');
     } catch (e) {
-      expect(e.message).toMatch(
-        'Could not find any module by the name "not-exist"',
-      );
+      expect(e.message).toMatchSnapshot();
     }
   });
 
@@ -27,8 +23,8 @@ describe('get', () => {
     try {
       getAction(workspace, 'dest');
     } catch (e) {
-      expect(e.message).toMatch('Could not find any module by the name "dest"');
-      expect(e.message).toMatch(`Did you mean "${chalk.bold('t')}est"?`);
+      expect(e.message).toMatchSnapshot();
+      expect(e.message).toMatchSnapshot();
     }
   });
 
@@ -36,34 +32,27 @@ describe('get', () => {
     const workspace = resolveWorkspace('module-in-depth');
     const output = getAction(workspace, 'test');
 
-    expect(output).toMatch(`${chalk.underline('test')}
-└─┬ ${chalk.grey('another')}
-  └── 1.0.0`);
+    expect(output).toMatchSnapshot();
   });
 
   it('should get the version of a single module when not starting at the root', () => {
     const workspace = resolveWorkspace('single-module/node_modules');
     const output = getAction(workspace, 'test');
 
-    expect(output).toMatch(`${chalk.underline('test')}
-└── 1.0.0`);
+    expect(output).toMatchSnapshot();
   });
 
   it('should get the version of a single module when in a scoped package', () => {
     const workspace = resolveWorkspace('scoped-module');
     const output = getAction(workspace, '@scope/test');
 
-    expect(output).toMatch(`${chalk.underline('@scope/test')}
-└── 1.0.0`);
+    expect(output).toMatchSnapshot();
   });
 
   it('should print versions in three levels deep including ancestors', () => {
     const workspace = resolveWorkspace('three-levels-deep');
     const output = getAction(workspace, 'dep-of-dep-of-dep');
 
-    expect(output).toMatch(`${chalk.underline('dep-of-dep-of-dep')}
-└─┬ ${chalk.grey('dep')}
-  └─┬ ${chalk.grey('dep-of-dep')}
-    └── 1.0.0`);
+    expect(output).toMatchSnapshot();
   });
 });

--- a/__tests__/actions/list.spec.js
+++ b/__tests__/actions/list.spec.js
@@ -1,4 +1,3 @@
-const chalk = require('chalk');
 const listAction = require('../../src/actions/list');
 const { resolveWorkspace } = require('../utils');
 
@@ -7,15 +6,6 @@ describe('list', () => {
     const workspace = resolveWorkspace('mix-modules');
     const output = listAction(workspace);
 
-    expect(output).toMatch(`${chalk.underline('@scope/test')}
-└── 1.0.0
-
-${chalk.underline('another')}
-└── 1.0.0
-
-${chalk.underline('test')}
-├── 1.0.0
-└─┬ ${chalk.grey('another')}
-  └── 1.0.0`);
+    expect(output).toMatchSnapshot();
   });
 });

--- a/__tests__/actions/match.spec.js
+++ b/__tests__/actions/match.spec.js
@@ -1,4 +1,3 @@
-const chalk = require('chalk');
 const matchAction = require('../../src/actions/match');
 const { resolveWorkspace } = require('../utils');
 
@@ -7,8 +6,7 @@ describe('match', () => {
     const workspace = resolveWorkspace('mix-modules');
     const output = matchAction(workspace, 'anot');
 
-    expect(output).toMatch(`${chalk.underline(`${chalk.magenta('anot')}her`)}
-└── 1.0.0`);
+    expect(output).toMatchSnapshot();
   });
 
   it('should show a message when no module has matched the provided string', () => {
@@ -16,7 +14,7 @@ describe('match', () => {
     try {
       matchAction(workspace, 'bla');
     } catch (e) {
-      expect(e.message).toMatch('Could not find any module that matches "bla"');
+      expect(e.message).toMatchSnapshot();
     }
   });
 });

--- a/__tests__/cli.spec.js
+++ b/__tests__/cli.spec.js
@@ -11,32 +11,28 @@ describe('CLI', () => {
       const cwd = resolveFixture('single-module');
       const output = runCommand('test', { cwd });
 
-      expect(output).toMatch(`test
-└── 1.0.0`);
+      expect(output).toMatchSnapshot();
     });
 
     it('should show get matchs when using the match command', () => {
       const cwd = resolveFixture('single-module');
       const output = runCommand('match te', { cwd });
 
-      expect(output).toMatch(`test
-└── 1.0.0`);
+      expect(output).toMatchSnapshot();
     });
 
     it('should add dependents information when using thw --why option', () => {
       const cwd = resolveFixture('single-module');
       const output = runCommand('--why test', { cwd });
 
-      expect(output).toMatch(`test
-└── 1.0.0 (devDependencies, npm install test)`);
+      expect(output).toMatchSnapshot();
     });
 
     it('should add dependents information when using thw -w option', () => {
       const cwd = resolveFixture('single-module');
       const output = runCommand('-w test', { cwd });
 
-      expect(output).toMatch(`test
-└── 1.0.0 (devDependencies, npm install test)`);
+      expect(output).toMatchSnapshot();
     });
   });
 
@@ -45,34 +41,14 @@ describe('CLI', () => {
       const cwd = resolveFixture('mix-modules');
       const output = runCommand('list', { cwd });
 
-      expect(output).toMatch(`@scope/test
-└── 1.0.0
-
-another
-└── 1.0.0
-
-test
-├── 1.0.0
-└─┬ another
-  └── 1.0.0`);
+      expect(output).toMatchSnapshot();
     });
 
     it('should show modules mentioned in package.json', () => {
       const cwd = resolveFixture('indirect-dependencies');
       const output = runCommand('list --deps', { cwd });
 
-      expect(output).toMatch(`dependency1
-└── 1.0.0
-
-dependency2
-└── 1.0.0
-
-devDependency1
-└── 1.0.0
-
-devDependency2
-└── 1.0.0
-`);
+      expect(output).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
This PR compares test results to snapshots in separate files instead of manually comparing them with string results.