### PR TITLE
Fix a bug when running `qnm` in a monorepo doesn't return

### DIFF
--- a/src/workspace/workspace.ts
+++ b/src/workspace/workspace.ts
@@ -199,13 +199,13 @@ export default class Workspace {
 
     packages.forEach(location => {
       try {
-        this.packages.push(Workspace.loadSync(location));
+        this.packages.push(Workspace.loadSync(location, false));
       } catch (error) {}
     });
   }
 
-  static loadSync(cwd = process.cwd()): Workspace {
-    const root = pkgDir.sync(cwd);
+  static loadSync(cwd = process.cwd(), traverse = true): Workspace {
+    const root = traverse ? pkgDir.sync(cwd) : cwd;
 
     if (!root) {
       throw new Error('could not identify package directory');


### PR DESCRIPTION
do not try to traverse up when trying to identify the workspace root in a monorepo sub package.

It seems that sometime when trying to resolve a workspace, we resolve the monorepo root instead, this leads to an infinite loop resulting with `qnm` returning nothing 😢 

This PR is a quick fix to this problem