### PR TITLE
Do not throw in case module wasn't found on the fs

### DIFF
--- a/src/workspace/modules-map.ts
+++ b/src/workspace/modules-map.ts
@@ -61,9 +61,13 @@ export default class ModulesMap extends Map<string, Array<NodeModule>> {
         const DependencyModuleOccurrences = this.get(dependency);
 
         if (!DependencyModuleOccurrences) {
-          throw new Error(
+          console.error(
             `The module ${dependency} specified in yarn.lock but is not on the file system`,
           );
+
+          // Do not fail in this case, maybe the user is intereseted in a different module
+          // and this information doesn't interesting to them
+          return;
         }
 
         // We're only interesetd in requiredBy if the module is on the root

--- a/src/workspace/modules-map.ts
+++ b/src/workspace/modules-map.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import chalk from 'chalk';
 import NodeModule from './node-module';
 import Workspace from './workspace';
 import flattenDeep from 'lodash/flattenDeep';
@@ -62,7 +63,9 @@ export default class ModulesMap extends Map<string, Array<NodeModule>> {
 
         if (!DependencyModuleOccurrences) {
           console.error(
-            `The module ${dependency} specified in yarn.lock but is not on the file system`,
+            chalk.dim(
+              `Warning: The module ${dependency} specified in yarn.lock but is not on the file system`,
+            ),
           );
 
           // Do not fail in this case, maybe the user is intereseted in a different module


### PR DESCRIPTION
There are cases when there is a module specified in the `yarn.lock` file but it doesn't located on the file-system.
While this is an edge case and may indicate on a bug, it also can be something that the user doesn't care about.
The outcome of throwing an error is that `qnm --why` would not work for cases like this.

This PR makes this a warning but still gives the relevant output:

BEFORE:
![image](https://user-images.githubusercontent.com/11733036/90621217-18b99a80-e21c-11ea-9e0e-6f99ad2ecb89.png)

AFTER:
![image](https://user-images.githubusercontent.com/11733036/90621179-09d2e800-e21c-11ea-9523-792d0c93f2e2.png)
