### PR TITLE
Show --why information by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ Use `qnm` command without arguments to trigger an [`fzf`](https://github.com/jun
 
 ## Options
 
-### -w, --why
-
-Add information regarding why this package was installed in the first place, by showing its dependent packages.
-
 ### -o , --open
 
 Open the module's `package.json` file with the default editor.

--- a/src/__tests__/__snapshots__/cli.spec.ts.snap
+++ b/src/__tests__/__snapshots__/cli.spec.ts.snap
@@ -1,43 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CLI qnm <module>] should add dependents information when using the --why option 1`] = `
-"test
-└── 1.0.0 (devDependencies, npm install test)
-
-"
-`;
-
-exports[`CLI qnm <module>] should add dependents information when using the --why option on yarn installed package 1`] = `
+exports[`CLI qnm <module>] should add dependents information on yarn installed package 1`] = `
 "import-from
 └── 3.0.0 (import-cwd)
 
 "
 `;
 
-exports[`CLI qnm <module>] should add dependents information when using thw -w option 1`] = `
+exports[`CLI qnm <module>] should show an indication in case there is a symlink 1`] = `
+"test
+└── 1.0.0 -> ../../symlink-origin/node_modules/test (devDependencies, npm install test)
+
+"
+`;
+
+exports[`CLI qnm <module>] should show get matches when using the match command 1`] = `
 "test
 └── 1.0.0 (devDependencies, npm install test)
 
 "
 `;
 
-exports[`CLI qnm <module>] should show an indication in case there is a symlink 1`] = `
+exports[`CLI qnm <module>] should show the version and dependents info on a single module when called with a string 1`] = `
 "test
-└── 1.0.0 -> ../../symlink-origin/node_modules/test
-
-"
-`;
-
-exports[`CLI qnm <module>] should show get matchs when using the match command 1`] = `
-"test
-└── 1.0.0
-
-"
-`;
-
-exports[`CLI qnm <module>] should show the version on a single module when called with a string 1`] = `
-"test
-└── 1.0.0
+└── 1.0.0 (devDependencies, npm install test)
 
 "
 `;

--- a/src/__tests__/actions/__snapshots__/get.spec.ts.snap
+++ b/src/__tests__/actions/__snapshots__/get.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`get should get the version of a module in depth 1`] = `
 
 exports[`get should get the version of a single module 1`] = `
 "[4mtest[24m
-└── [37m1.0.0[39m
+└── [37m1.0.0[39m [33m(devDependencies, npm install test)[39m
 "
 `;
 
@@ -30,7 +30,7 @@ exports[`get should get the version of a single module when in a scoped package 
 
 exports[`get should get the version of a single module when not starting at the root 1`] = `
 "[4mtest[24m
-└── [37m1.0.0[39m
+└── [37m1.0.0[39m [33m(devDependencies, npm install test)[39m
 "
 `;
 

--- a/src/__tests__/actions/__snapshots__/list.spec.ts.snap
+++ b/src/__tests__/actions/__snapshots__/list.spec.ts.snap
@@ -27,9 +27,3 @@ exports[`list should list the versions of mixed modules 1`] = `
   └── [37m1.0.0[39m
 "
 `;
-
-exports[`list should show why info 1`] = `
-"[4mtest[24m
-└── [37m1.0.0[39m [33m(devDependencies, npm install test)[39m
-"
-`;

--- a/src/__tests__/actions/__snapshots__/match.spec.ts.snap
+++ b/src/__tests__/actions/__snapshots__/match.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`match should disable colors 1`] = `
-"[4m[35manot[39mher[24m
-└── 1.0.0
+"[4m[35mtes[39mt[24m
+└── 1.0.0 [33m(devDependencies, npm install test)[39m
 "
 `;
 
@@ -13,9 +13,3 @@ exports[`match should print the matched modules according to passed string 1`] =
 `;
 
 exports[`match should show a message when no module has matched the provided string 1`] = `"Could not find any module that matches \\"bla\\""`;
-
-exports[`match should show why info 1`] = `
-"[4m[35mtes[39mt[24m
-└── [37m1.0.0[39m [33m(devDependencies, npm install test)[39m
-"
-`;

--- a/src/__tests__/actions/list.spec.ts
+++ b/src/__tests__/actions/list.spec.ts
@@ -17,13 +17,4 @@ describe('list', () => {
 
     expect(output).toMatchSnapshot();
   });
-
-  it('should show why info', () => {
-    const workspace = resolveWorkspace('single-module');
-    const output = listAction(workspace, {
-      why: true,
-    });
-
-    expect(output).toMatchSnapshot();
-  });
 });

--- a/src/__tests__/actions/match.spec.ts
+++ b/src/__tests__/actions/match.spec.ts
@@ -10,18 +10,9 @@ describe('match', () => {
   });
 
   it('should disable colors', () => {
-    const workspace = resolveWorkspace('mix-modules');
-    const output = matchAction(workspace, 'anot', {
-      noColor: true,
-    });
-
-    expect(output).toMatchSnapshot();
-  });
-
-  it('should show why info', () => {
     const workspace = resolveWorkspace('single-module');
     const output = matchAction(workspace, 'tes', {
-      why: true,
+      noColor: true,
     });
 
     expect(output).toMatchSnapshot();

--- a/src/__tests__/cli.spec.ts
+++ b/src/__tests__/cli.spec.ts
@@ -19,37 +19,23 @@ const runCommand = (
 
 describe('CLI', () => {
   describe('qnm <module>]', () => {
-    it('should show the version on a single module when called with a string', () => {
+    it('should show the version and dependents info on a single module when called with a string', () => {
       const cwd = resolveFixture('single-module');
       const output = runCommand('test', { cwd });
 
       expect(output).toMatchSnapshot();
     });
 
-    it('should show get matchs when using the match command', () => {
+    it('should show get matches when using the match command', () => {
       const cwd = resolveFixture('single-module');
       const output = runCommand('match te', { cwd });
 
       expect(output).toMatchSnapshot();
     });
 
-    it('should add dependents information when using the --why option', () => {
-      const cwd = resolveFixture('single-module');
-      const output = runCommand('--why test', { cwd });
-
-      expect(output).toMatchSnapshot();
-    });
-
-    it('should add dependents information when using the --why option on yarn installed package', () => {
+    it('should add dependents information on yarn installed package', () => {
       const cwd = resolveFixture('yarn-install');
-      const output = runCommand('--why import-from', { cwd });
-
-      expect(output).toMatchSnapshot();
-    });
-
-    it('should add dependents information when using thw -w option', () => {
-      const cwd = resolveFixture('single-module');
-      const output = runCommand('-w test', { cwd });
+      const output = runCommand('import-from', { cwd });
 
       expect(output).toMatchSnapshot();
     });
@@ -105,14 +91,14 @@ describe('CLI', () => {
 
     it('should list dependencies in a yarn installed package and show "why" information', () => {
       const cwd = resolveFixture('yarn-install');
-      const output = runCommand('list --why', { cwd });
+      const output = runCommand('list', { cwd });
 
       expect(output).toMatchSnapshot();
     });
 
     it('should list a monorepo', () => {
       const cwd = resolveFixture('monorepo');
-      const output = runCommand('list --why', { cwd });
+      const output = runCommand('list', { cwd });
 
       expect(output).toMatchSnapshot();
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,6 @@ const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
 updateNotifier({ pkg }).notify();
 
 export type CliOptions = {
-  why?: boolean;
   deps?: boolean;
   noColor?: boolean;
   open?: boolean;
@@ -31,10 +30,6 @@ try {
     .version(pkg.version)
     //@ts-ignore
     .arguments('[module]', 'prints module version from the node_modules')
-    .option(
-      '-w, --why',
-      'add information regarding why this package was installed',
-    )
     .option('-d, --debug', 'see full error messages, mostly for debugging')
     .option('-o, --open', 'open editor at the package.json of a chosen module')
     .option('--disable-colors', 'minimize color and styling usage in output')
@@ -55,21 +50,16 @@ try {
     .description('list all node_modules with their versions')
     .option(
       '--deps',
-      'list dependencies and devDependencies based on package.json.',
+      'list dependencies and devDependencies based on package.json.'
     )
-    .option(
-      '-w, --why',
-      'add information regarding why packages were installed',
-    )
-    .action(cmd => {
-      const { disableColors, why } = program;
+    .action((cmd) => {
+      const { disableColors } = program;
       const workspace = Workspace.loadSync();
 
       console.log(
         listAction(workspace, {
           deps: cmd.deps,
           noColor: disableColors,
-          why,
         }),
       );
     });
@@ -77,17 +67,11 @@ try {
   program
     .command('match <string>')
     .description('prints modules which matches the provided string')
-    .option(
-      '-w, --why',
-      'add information regarding why packages were installed',
-    )
-    .action(string => {
-      const { disableColors, why } = program;
+    .action((string) => {
+      const { disableColors } = program;
       const workspace = Workspace.loadSync();
 
-      console.log(
-        matchAction(workspace, string, { noColor: disableColors, why }),
-      );
+      console.log(matchAction(workspace, string, { noColor: disableColors }));
     });
 
   program.parse(process.argv);
@@ -98,10 +82,9 @@ try {
 
   const workspace = Workspace.loadSync();
 
-  const { why, deps, disableColors, open, homepage } = program;
+  const { deps, disableColors, open, homepage } = program;
 
   const options: CliOptions = {
-    why,
     deps,
     noColor: disableColors,
     open,

--- a/src/render/render-module-occurrences.ts
+++ b/src/render/render-module-occurrences.ts
@@ -17,8 +17,8 @@ const getWhyInfo = (m: NodeModule) => {
 
 type TreeNode = { label: string; nodes: Array<TreeNode> } | string;
 
-const buildWithAncestors = (m: NodeModule, { why, noColor }: CliOptions) => {
-  const whyInfo = why ? getWhyInfo(m) : '';
+const buildWithAncestors = (m: NodeModule, { noColor }: CliOptions) => {
+  const whyInfo = getWhyInfo(m);
   const version = noColor ? m.version : renderVersion(m.name, m.version);
   const symlink = m.symlink ? chalk.magenta(` -> ${m.symlink}`) : '';
   const information = version + symlink + whyInfo;
@@ -39,13 +39,12 @@ const buildWithAncestors = (m: NodeModule, { why, noColor }: CliOptions) => {
 
 export default (
   moduleOccurrences: Array<NodeModule>,
-  { match, why, noColor }: CliOptions = {},
-  monorepoPackageName?: string,
+  { match, noColor }: CliOptions = {},
+  monorepoPackageName?: string
 ) => {
   const moduleName = highlightMatch(moduleOccurrences[0].name, match!);
   const buildedOccurrences = moduleOccurrences.map(m =>
     buildWithAncestors(m, {
-      why,
       noColor,
     }),
   );

--- a/src/workspace/workspace.ts
+++ b/src/workspace/workspace.ts
@@ -58,12 +58,14 @@ export default class Workspace {
   }
 
   get yarnLock(): YarnLock {
-    const yarnLockPath = path.join(this.root, 'yarn.lock');
-    const rawYarnLock = fs.readFileSync(yarnLockPath, 'utf8');
-    const yarnLock = parseYarnLock(rawYarnLock).object as YarnLock;
-    this._yarnLock = yarnLock;
+    if (!this._yarnLock) {
+      const yarnLockPath = path.join(this.root, 'yarn.lock');
+      const rawYarnLock = fs.readFileSync(yarnLockPath, 'utf8');
+      const yarnLock = parseYarnLock(rawYarnLock).object as YarnLock;
+      this._yarnLock = yarnLock;
+    }
 
-    return yarnLock;
+    return this._yarnLock;
   }
 
   get name() {


### PR DESCRIPTION
Hello,

This PR:

- improves `qnm` performance with yarn lock. There was no caching for yarn lock contents and therefore it was loaded for every dependency in the output.
- Now every command shows `--why` info by default. The `--why` option was completely removed (closes #46)

Can you please also add `hacktoberfest-accepted` label for this PR, so that it counts for hacktoberfest challenge (I still hope to get all PRs done :sweat_smile:)