### PR TITLE
Suggest if you see a scoped package with the same name

### DIFF
--- a/src/__tests__/cli.spec.ts
+++ b/src/__tests__/cli.spec.ts
@@ -1,11 +1,15 @@
-import { execSync } from 'child_process';
+import { execSync, StdioOptions } from 'child_process';
 import { resolveFixture } from './utils';
 
 const qnmBin = require.resolve('../../bin/qnm');
 
 const runCommand = (
   command: string,
-  { cwd, env }: { cwd: string; env?: Record<string, any> },
+  {
+    cwd,
+    env,
+    stdio,
+  }: { cwd: string; env?: Record<string, any>; stdio?: StdioOptions },
 ) =>
   execSync(`${qnmBin} ${command}`, {
     cwd,
@@ -14,6 +18,7 @@ const runCommand = (
       FORCE_COLOR: '0',
       ...env,
     },
+    stdio,
     encoding: 'utf-8',
   });
 
@@ -59,6 +64,17 @@ describe('CLI', () => {
       const output = runCommand('package-foo', { cwd });
 
       expect(output).toMatchSnapshot();
+    });
+
+    it('should provide suggestion for scoped package with the same name', () => {
+      const cwd = resolveFixture('scoped-package');
+      expect.assertions(1);
+
+      try {
+        runCommand('test', { cwd, stdio: 'pipe' });
+      } catch (error) {
+        expect(error.message).toMatch('Did you mean "@scope/test"');
+      }
     });
   });
 

--- a/src/__tests__/fixtures/scoped-package/node_modules/@scope/test/package.json
+++ b/src/__tests__/fixtures/scoped-package/node_modules/@scope/test/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scope/test",
+  "version": "1.0.0",
+  "_requiredBy": ["#DEV:/", "#USER"]
+}

--- a/src/__tests__/fixtures/scoped-package/package.json
+++ b/src/__tests__/fixtures/scoped-package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "single-module",
+  "version": "1.0.0"
+}

--- a/src/suggest/get-suggestions.ts
+++ b/src/suggest/get-suggestions.ts
@@ -5,6 +5,16 @@ export default (
   options: Array<string>,
   maxDistance: number = 2,
 ): Array<string> => {
+  for (const option of options) {
+    if (
+      option.startsWith('@') &&
+      option.indexOf('/') &&
+      option.slice(option.indexOf('/') + 1) === input
+    ) {
+      return [option];
+    }
+  }
+
   return options
     .map((opt) => {
       return [opt, levenshtein(input, opt)] as [string, number];


### PR DESCRIPTION
Now qnm will suggest if it find a scoped module by the same name as the input.

![image](https://user-images.githubusercontent.com/11733036/110885213-1cfbf100-82ef-11eb-8757-ec538015b73a.png)

Thanks to @ronami for the great suggestion