### PR TITLE
Add a terminal link to a package location if supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,9 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "update-notifier": "^5.0.1",
-    "tabtab": "2"
+    "tabtab": "2",
+    "terminal-link": "^2.1.1",
+    "update-notifier": "^5.0.1"
   },
   "bundledDependencies": [
     "update-notifier",

--- a/package.json
+++ b/package.json
@@ -67,13 +67,13 @@
     "pkg-dir": "^5.0.0",
     "prettier": "^2.2.1",
     "prompts": "^2.3.0",
+    "terminal-link": "^2.1.1",
     "ts-jest": "^26.4.4",
     "type-fest": "^0.20.2",
     "typescript": "^4.1.3"
   },
   "dependencies": {
     "tabtab": "2",
-    "terminal-link": "^2.1.1",
     "update-notifier": "^5.0.1"
   },
   "bundledDependencies": [

--- a/src/render/render-module-occurrences.ts
+++ b/src/render/render-module-occurrences.ts
@@ -1,6 +1,10 @@
+import path from 'path';
 import chalk from 'chalk';
 import isEmpty from 'lodash/isEmpty';
 import archy from 'archy';
+import terminalLink, {
+  isSupported as isTerminalLinkSupported,
+} from 'terminal-link';
 import NodeModule from '../workspace/node-module';
 import { CliOptions } from '../cli';
 import renderVersion from './render-version';
@@ -20,8 +24,11 @@ type TreeNode = { label: string; nodes: Array<TreeNode> } | string;
 const buildWithAncestors = (m: NodeModule, { noColor }: CliOptions) => {
   const whyInfo = getWhyInfo(m);
   const version = noColor ? m.version : renderVersion(m.name, m.version);
+  const versionWithLink = isTerminalLinkSupported
+    ? terminalLink(version, path.join('File:///', m.path, 'package.json'))
+    : version;
   const symlink = m.symlink ? chalk.magenta(` -> ${m.symlink}`) : '';
-  const information = version + symlink + whyInfo;
+  const information = versionWithLink + symlink + whyInfo;
 
   let hierarchy: Array<TreeNode> = [information];
 


### PR DESCRIPTION
This PR adds a link with a path to the relevant `package.json`

This feature adds clarity to qnm (e.g. what are those numbers represent?) and gives you an easy way to watch the package.json with a click of a button.

This might be a small feature, but I believe that it can help a lot speed things up an on board new users.

This is another great idea from @ronami ❤️ 

![terminal-link-qnm](https://user-images.githubusercontent.com/11733036/113167198-29b79900-924c-11eb-8a72-c5c96f3b6eb2.gif)
