### PR TITLE
test: fix runCommand when path has spaces

### DIFF
--- a/src/__tests__/cli.spec.ts
+++ b/src/__tests__/cli.spec.ts
@@ -11,7 +11,7 @@ const runCommand = (
     stdio,
   }: { cwd: string; env?: Record<string, any>; stdio?: StdioOptions }
 ) =>
-  execSync(`${qnmBin} ${command}`, {
+  execSync(`node "${qnmBin}" ${command}`, {
     cwd,
     env: {
       ...process.env,


### PR DESCRIPTION
Use `node "${qnmBin}"` instead of `${qnmBin}` directly to solve two issues:

- Tests failed when absolute path of qnm repository has spaces. Example:
`/path/i have spaces/qnm`
- `bin/qnm.js` is not always made executable when cloned on windows to rely on node shebang.

Note: `""` instead of `''` to escape spaces on Windows too.

> This is a prefix to work on #98 and #97