### PR TITLE
Use the correct latest time for last modified indication

### DIFF
--- a/src/render/render-module-occurrences.ts
+++ b/src/render/render-module-occurrences.ts
@@ -120,8 +120,10 @@ export default (
 
   if (remote) {
     const latest = moduleOccurrences[0].latestVersion;
-    const lastModified = moduleOccurrences[0].lastModified;
-    latestInfo = chalk.green.dim(` ${latest} ↰ ${formatTime(lastModified)}`);
+    const latestLastModified = moduleOccurrences[0].latestLastModified;
+    latestInfo = chalk.green.dim(
+      ` ${latest} ↰ ${formatTime(latestLastModified)}`
+    );
   }
 
   const packageInfo = {

--- a/src/workspace/node-module.ts
+++ b/src/workspace/node-module.ts
@@ -108,8 +108,8 @@ export default class NodeModule {
     return this.remoteData['dist-tags'].latest;
   }
 
-  get lastModified(): Date {
-    return new Date(this.remoteData.time.modified);
+  get latestLastModified(): Date {
+    return new Date(this.remoteData.time[this.latestVersion]);
   }
 
   get releaseDate(): Date {


### PR DESCRIPTION
qnm had a bug where it showed the last modified time of the npm package while most users actually want to know the last modification of the latest version.

So it showed an incorrect view of a latest version with the last modified value of the next version.

This PR makes sure qnm takes the latest tag modification date.