### PR TITLE
Show max version on the same major

### DIFF
--- a/src/__tests__/__snapshots__/cli.spec.ts.snap
+++ b/src/__tests__/__snapshots__/cli.spec.ts.snap
@@ -27,7 +27,7 @@ exports[`CLI qnm <module>] should mark bundledDependencies 1`] = `
 `;
 
 exports[`CLI qnm <module>] should mark resolutions 1`] = `
-"test 3.0.0 ↰ just now
+"test 3.0.0 ↰ just now | 2.3.4 ↰ just now
 └─┬ dep
   └── 2.0.0 (resolutions) ⇡ just now
 "
@@ -62,7 +62,7 @@ exports[`CLI qnm <module>] should work in monorepo and print subpackages modules
 └── 1.0.0 ⇡ just now
 
 package-a
-└─┬ package-foo 3.0.0 ↰ just now
+└─┬ package-foo 3.0.0 ↰ just now | 2.3.4 ↰ just now
   └── 2.0.0 ⇡ just now
 "
 `;
@@ -72,7 +72,7 @@ exports[`CLI qnm <module>] should work in monorepo with yarn workspaces 1`] = `
 └── 1.0.0 ⇡ just now
 
 package-a
-└─┬ package-foo 3.0.0 ↰ just now
+└─┬ package-foo 3.0.0 ↰ just now | 2.3.4 ↰ just now
   └── 2.0.0 ⇡ just now
 "
 `;

--- a/src/render/render-module-occurrences.ts
+++ b/src/render/render-module-occurrences.ts
@@ -119,10 +119,28 @@ export default (
   let latestInfo = '';
 
   if (remote) {
-    const latest = moduleOccurrences[0].latestVersion;
-    const latestLastModified = moduleOccurrences[0].latestLastModified;
+    const {
+      latestVersion,
+      latestLastModified,
+      maxVersionInSameMajor,
+      maxVersionInSameMajorLastModified,
+    } = moduleOccurrences[0];
+
+    let maxVersionInSameMajorStr = '';
+
+    if (
+      latestVersion !== maxVersionInSameMajor &&
+      maxVersionInSameMajorLastModified
+    ) {
+      maxVersionInSameMajorStr = ` | ${maxVersionInSameMajor} ↰ ${formatTime(
+        maxVersionInSameMajorLastModified
+      )}`;
+    }
+
     latestInfo = chalk.green.dim(
-      ` ${latest} ↰ ${formatTime(latestLastModified)}`
+      ` ${latestVersion} ↰ ${formatTime(
+        latestLastModified
+      )}${maxVersionInSameMajorStr}`
     );
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,7 @@ export function npmView(packageName: string): RemoteData {
         created: Date.now().toString(),
         modified: Date.now().toString(),
       },
+      versions: ['2.3.4', '3.0.0'],
       'dist-tags': { latest: '3.0.0' },
     };
   }

--- a/src/workspace/node-module.ts
+++ b/src/workspace/node-module.ts
@@ -4,9 +4,12 @@ import { PackageJson } from 'type-fest';
 import getFolderSize from 'get-folder-size';
 import { readLinkSilent, npmView } from '../utils';
 import Workspace from './workspace';
+import semverMaxSatisfying from 'semver/ranges/max-satisfying';
+import semver from 'semver';
 
 export type RemoteData = {
   time: Record<string | 'modified' | 'created', string>;
+  versions: Array<string>;
   'dist-tags': Record<'latest' | string, string>;
 };
 
@@ -110,6 +113,19 @@ export default class NodeModule {
 
   get latestLastModified(): Date {
     return new Date(this.remoteData.time[this.latestVersion]);
+  }
+
+  get maxVersionInSameMajor(): string | null {
+    return semverMaxSatisfying(
+      this.remoteData.versions,
+      `^${semver.clean(this.version)}`
+    );
+  }
+
+  get maxVersionInSameMajorLastModified(): Date | null {
+    if (!this.maxVersionInSameMajor) return null;
+
+    return new Date(this.remoteData.time[this.maxVersionInSameMajor]);
   }
 
   get releaseDate(): Date {


### PR DESCRIPTION
Today, qnm shows you the latest version and when it was released, the idea that it's useful to know this information when you debug dependency related issues.

In some cases, updating a major is not an option, but understanding that you can update a few minor versions will be useful.

In this PR qnm will try to add the information of the max version of the same major that you dependency is located on.

![image](https://user-images.githubusercontent.com/11733036/175027414-96c92bbc-f557-4775-85f4-dcbf9c4f1dec.png)
