### PR TITLE
Support running in empty package in monorepo

### DIFF
--- a/src/__tests__/__snapshots__/cli.spec.ts.snap
+++ b/src/__tests__/__snapshots__/cli.spec.ts.snap
@@ -193,3 +193,9 @@ dep-of-dep-of-dep
 
 "
 `;
+
+exports[`CLI qnm list should support an empty module in a monorepo 1`] = `
+"camelcase 3.0.0 ↰ just now
+└── 1.0.0 ⇡ just now
+"
+`;

--- a/src/__tests__/__snapshots__/cli.spec.ts.snap
+++ b/src/__tests__/__snapshots__/cli.spec.ts.snap
@@ -194,7 +194,7 @@ dep-of-dep-of-dep
 "
 `;
 
-exports[`CLI qnm list should support an empty module in a monorepo 1`] = `
+exports[`CLI qnm list should support an empty package in a monorepo 1`] = `
 "camelcase 3.0.0 ↰ just now
 └── 1.0.0 ⇡ just now
 "

--- a/src/__tests__/__snapshots__/workspace.spec.ts.snap
+++ b/src/__tests__/__snapshots__/workspace.spec.ts.snap
@@ -1,5 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`workspace should throw an error for no node_modules case 1`] = `[Error: could not find node_modules directory]`;
-
 exports[`workspace should throw an error for no package case 1`] = `[Error: could not identify package directory]`;

--- a/src/__tests__/cli.spec.ts
+++ b/src/__tests__/cli.spec.ts
@@ -2,6 +2,7 @@ import { execSync, StdioOptions } from 'child_process';
 import { resolveFixture } from './utils';
 // @ts-expect-error no typings
 import replaceall from 'replaceall';
+import path from 'path';
 
 const qnmBin = require.resolve('../../bin/qnm');
 
@@ -165,14 +166,18 @@ describe('CLI', () => {
     });
 
     it('should support an empty package in a monorepo', () => {
-      const cwd = resolveFixture('monorepo/packages/package-without-modules');
+      const cwd = resolveFixture(
+        path.join('monorepo', 'packages', 'package-without-modules')
+      );
       const output = runCommand('camelcase', { cwd });
 
       expect(output).toMatchSnapshot();
     });
 
     it('should throw correctly when module is not found in a monorepo', () => {
-      const cwd = resolveFixture('monorepo/packages/package-without-modules');
+      const cwd = resolveFixture(
+        path.join('monorepo', 'packages', 'package-without-modules')
+      );
 
       try {
         runCommand('does-not-exists', { cwd, stdio: 'pipe' });

--- a/src/__tests__/cli.spec.ts
+++ b/src/__tests__/cli.spec.ts
@@ -164,15 +164,15 @@ describe('CLI', () => {
       expect(output).toMatchSnapshot();
     });
 
-    it('should support an empty module in a monorepo', () => {
-      const cwd = resolveFixture('monorepo/packages/package-no-modules');
+    it('should support an empty package in a monorepo', () => {
+      const cwd = resolveFixture('monorepo/packages/package-without-modules');
       const output = runCommand('camelcase', { cwd });
 
       expect(output).toMatchSnapshot();
     });
 
     it('should throw correctly when module is not found in a monorepo', () => {
-      const cwd = resolveFixture('monorepo/packages/package-no-modules');
+      const cwd = resolveFixture('monorepo/packages/package-without-modules');
 
       try {
         runCommand('does-not-exists', { cwd, stdio: 'pipe' });

--- a/src/__tests__/cli.spec.ts
+++ b/src/__tests__/cli.spec.ts
@@ -163,5 +163,24 @@ describe('CLI', () => {
 
       expect(output).toMatchSnapshot();
     });
+
+    it('should support an empty module in a monorepo', () => {
+      const cwd = resolveFixture('monorepo/packages/package-no-modules');
+      const output = runCommand('camelcase', { cwd });
+
+      expect(output).toMatchSnapshot();
+    });
+
+    it('should throw correctly when module is not found in a monorepo', () => {
+      const cwd = resolveFixture('monorepo/packages/package-no-modules');
+
+      try {
+        runCommand('does-not-exists', { cwd, stdio: 'pipe' });
+      } catch (error: any) {
+        expect(error.message).toMatch(
+          'Could not find any module by the name: "does-not-exists"'
+        );
+      }
+    });
   });
 });

--- a/src/__tests__/fixtures/monorepo/node_modules/camelcase/package.json
+++ b/src/__tests__/fixtures/monorepo/node_modules/camelcase/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "package-baz",
+  "name": "camelcase",
   "version": "1.0.0"
 }

--- a/src/__tests__/fixtures/monorepo/packages/package-no-modules/package.json
+++ b/src/__tests__/fixtures/monorepo/packages/package-no-modules/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-no-modules",
+  "version": "2.0.0"
+}

--- a/src/__tests__/fixtures/monorepo/packages/package-no-modules/package.json
+++ b/src/__tests__/fixtures/monorepo/packages/package-no-modules/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "package-no-modules",
-  "version": "2.0.0"
-}

--- a/src/__tests__/fixtures/monorepo/packages/package-without-modules/package.json
+++ b/src/__tests__/fixtures/monorepo/packages/package-without-modules/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-without-modules",
+  "version": "2.0.0"
+}

--- a/src/render/render-module-occurrences.ts
+++ b/src/render/render-module-occurrences.ts
@@ -129,6 +129,7 @@ export default (
   cwdModuleName?: string
 ) => {
   const moduleName = highlightMatch(moduleOccurrences[0].name, match!);
+
   const buildedOccurrences = moduleOccurrences.map((m) =>
     buildWithAncestors(
       m,

--- a/src/workspace/workspace.ts
+++ b/src/workspace/workspace.ts
@@ -83,6 +83,7 @@ export default class Workspace {
     const maybeParentMonorepo = Workspace.loadSync({ cwd: maybeMonrepoRoot });
     const isPackageInMonorepo = maybeParentMonorepo
       .getMonorepoPackages()
+      .map(path.normalize)
       .includes(this.root);
 
     if (isPackageInMonorepo) {

--- a/src/workspace/workspace.ts
+++ b/src/workspace/workspace.ts
@@ -38,6 +38,12 @@ export default class Workspace {
 
   get modulesMap(): ModulesMap {
     if (!this._modulesMap) {
+      const nodeModulesPath = path.join(this.root, 'node_modules');
+
+      if (!fs.existsSync(nodeModulesPath)) {
+        throw new Error('could not find node_modules directory');
+      }
+
       this._modulesMap = ModulesMap.loadSync(this.root, this);
 
       if (this._modulesMap.size === 0) {
@@ -321,12 +327,6 @@ export default class Workspace {
 
     if (!root) {
       throw new Error('could not identify package directory');
-    }
-
-    const nodeModulesPath = path.join(root, 'node_modules');
-
-    if (!fs.existsSync(nodeModulesPath)) {
-      throw new Error('could not find node_modules directory');
     }
 
     const workspace = new Workspace({ root });


### PR DESCRIPTION
Fixes #101 

This also improves error handling for cases remote registry is not approachable or a module doesn't exist on the remote registry.