### PR TITLE
Added empty line between HTML tag & markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Which means you have 3 occurrences of lodash in your `node_modules`:
 ### Fuzzy-search
 
 <img src="./assets/fuzzy-search.gif" alt="fuzzy-search" width="400px" height="400px" />
+
 Use `qnm` command without arguments to trigger an [`fzf`](https://github.com/junegunn/fzf) like fuzzy search.
 
 - Start typing to filter the matches from your `node_modules`


### PR DESCRIPTION
An empty line is needed after any HTML tag for GitHub to identify & pick the subsequent lines for Markdown rendering.

**Diff:**

![image](https://user-images.githubusercontent.com/19947758/178261139-c2e5cc2d-b821-46fe-ab49-35c00438ddda.png)

**Compare both:**
- [Before/Current](https://github.com/ranyitz/qnm/blob/master/README.md)
- [After](https://github.com/ajitzero/qnm/blob/patch-1/README.md)