### PR TITLE
remove unnecessary usage of lodash

### DIFF
--- a/src/actions/fuzzy-search.ts
+++ b/src/actions/fuzzy-search.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 import figures from 'figures';
 import logUpdate from 'log-update';
-import isEmpty from 'lodash/isEmpty';
 import Input from '../fuzzy-search/input';
 import sortBySimilarity from '../fuzzy-search/sort-by-similarity';
 import Workspace from '../workspace/workspace';
@@ -160,7 +159,7 @@ export default (workspace: Workspace, options: CliOptions): void => {
   });
 
   input.on('tab', () => {
-    if (isEmpty(results)) {
+    if (results.length === 0) {
       return;
     }
 
@@ -176,7 +175,7 @@ export default (workspace: Workspace, options: CliOptions): void => {
   });
 
   input.on('shiftTab', () => {
-    if (isEmpty(results)) {
+    if (results.length === 0) {
       return;
     }
 
@@ -192,14 +191,14 @@ export default (workspace: Workspace, options: CliOptions): void => {
   });
 
   input.on('choose', () => {
-    if (isEmpty(results) && isEmpty(chosenModules)) {
+    if (results.length === 0 && chosenModules.length === 0) {
       return;
     }
 
     input.end();
     logUpdate('');
 
-    if (isEmpty(chosenModules)) {
+    if (chosenModules.length === 0) {
       chosenModules.push(results[currentResult].value);
     }
 

--- a/src/actions/get.ts
+++ b/src/actions/get.ts
@@ -1,5 +1,4 @@
 import opn from 'open';
-import isEmpty from 'lodash/isEmpty';
 import getSuggestions from '../suggest/get-suggestions';
 import NotFoundModuleError from '../errors/not-found-module-error';
 import NotFoundHomepageError from '../errors/not-found-homepage-error';
@@ -26,7 +25,7 @@ export default (
 
   const { open, homepage, repo } = options;
 
-  if (isEmpty(moduleOccurrences)) {
+  if (moduleOccurrences.length === 0) {
     let suggestions: Array<string> = [];
 
     try {

--- a/src/actions/list.ts
+++ b/src/actions/list.ts
@@ -1,4 +1,3 @@
-import isEmpty from 'lodash/isEmpty';
 import NoModulesError from '../errors/no-modules-error';
 import renderModuleList from '../render/render-module-list';
 import Workspace from '../workspace/workspace';
@@ -13,7 +12,7 @@ export default (workspace: Workspace, options: CliOptions = {}) => {
 
   const moduleOccurrencesList = workspace.list();
 
-  if (isEmpty(moduleOccurrencesList)) {
+  if (moduleOccurrencesList.length === 0) {
     throw new NoModulesError();
   }
 

--- a/src/actions/match.ts
+++ b/src/actions/match.ts
@@ -1,4 +1,3 @@
-import isEmpty from 'lodash/isEmpty';
 import NotMatchModuleError from '../errors/not-match-module-error';
 import renderModuleList from '../render/render-module-list';
 import Workspace from '../workspace/workspace';
@@ -11,7 +10,7 @@ export default (
 ) => {
   const moduleOccurrencesList = workspace.match(match);
 
-  if (isEmpty(moduleOccurrencesList)) {
+  if (moduleOccurrencesList.length === 0) {
     throw new NotMatchModuleError(match);
   }
 

--- a/src/errors/not-found-module-error.ts
+++ b/src/errors/not-found-module-error.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import isEmpty from 'lodash/isEmpty';
 
 function paintDiffInBold(from: string, to: string) {
   return to
@@ -18,7 +17,7 @@ export default class NotFoundModuleError extends Error {
   constructor(name: string, suggestions: Array<string>) {
     let message = `Could not find any module by the name: "${name}".`;
 
-    if (!isEmpty(suggestions)) {
+    if (suggestions.length > 0) {
       message += ` Did you mean "${paintDiffInBold(name, suggestions[0])}"?`;
     }
 

--- a/src/render/render-module-occurrences.ts
+++ b/src/render/render-module-occurrences.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import chalk from 'chalk';
-import isEmpty from 'lodash/isEmpty';
 import archy from 'archy';
 import terminalLink, {
   isSupported as isTerminalLinkSupported,
@@ -51,7 +50,7 @@ const highlightMatch = (str: string, match: string) =>
 
 const getWhyInfo = (m: NodeModule) => {
   const { whyInfo } = m;
-  if (isEmpty(whyInfo) || m.parent) {
+  if (whyInfo.length === 0 || m.parent) {
     return '';
   }
 

--- a/src/render/render-version.ts
+++ b/src/render/render-version.ts
@@ -1,9 +1,9 @@
 import chalk, { Chalk } from 'chalk';
-import identity from 'lodash/identity';
 
-type Identity<T> = (t: T) => T;
+const identity = <T>(t: T) => t;
+type Identity = typeof identity;
 
-type VersionMap = Record<string, Chalk | Identity<string>>;
+type VersionMap = Record<string, Chalk | Identity>;
 
 const moduleMap: Record<string, VersionMap> = {};
 

--- a/src/workspace/modules-map.ts
+++ b/src/workspace/modules-map.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import flattenDeep from 'lodash/flattenDeep';
 import chalk from 'chalk';
 import NodeModule from './node-module';
 import Workspace from './workspace';
@@ -134,8 +133,8 @@ export default class ModulesMap extends Map<string, Array<NodeModule>> {
           .readdirSync(nodeModulesPath)
           .filter(isNotHiddenDirectory);
 
-        flattenDeep(
-          modulesNames.map((name) => {
+        modulesNames
+          .map((name) => {
             if (isScope(name)) {
               const subScopeModules = fs.readdirSync(
                 path.join(nodeModulesPath, name)
@@ -168,14 +167,15 @@ export default class ModulesMap extends Map<string, Array<NodeModule>> {
 
             return nodeModule;
           })
-        ).forEach((nodeModule) => {
-          // on yarn 3 with pnpm linker there are cases of circular dependency
-          // this makes sure that qnm isn't analyzing the same dependency twice
-          if (visited.has(nodeModule.realpath)) return;
-          visited.add(nodeModule.realpath);
+          .flat()
+          .forEach((nodeModule) => {
+            // on yarn 3 with pnpm linker there are cases of circular dependency
+            // this makes sure that qnm isn't analyzing the same dependency twice
+            if (visited.has(nodeModule.realpath)) return;
+            visited.add(nodeModule.realpath);
 
-          traverseNodeModules(nodeModule.path, nodeModule);
-        });
+            traverseNodeModules(nodeModule.path, nodeModule);
+          });
       }
     };
 


### PR DESCRIPTION
Reduce the unnecessary usage of lodash:

- Replace `lodash.isEmpty` with `.length === 0` (`qnm` only uses `lodash.isEmpty` on array).
- Replace `lodash.flattenDeep` with `Array.prototype.flat` (`Array.prototype.flat` is landed in ES2019 is supported since Node.js 11)

Before the PR:

```
$ yarn run build
ncc: Version 0.33.1
ncc: Compiling file index.js into CJS
ncc: Using typescript@4.5.4 (local user-provided)
  25kB  dist/xdg-open
1307kB  dist/index.js
1332kB  [5350ms] - ncc 0.33.1
```

After the PR:

```
$ yarn run build
ncc: Version 0.33.1
ncc: Compiling file index.js into CJS
ncc: Using typescript@4.5.4 (local user-provided)
  25kB  dist/xdg-open
1287kB  dist/index.js
1312kB  [4841ms] - ncc 0.33.1
```

The dist size is reduced by 20 KiB after the PR.