### PR TITLE
caching `NodeModule.path` and `NodeModule.maxVersionInSameMajor` getters

### DIFF
--- a/src/workspace/node-module.ts
+++ b/src/workspace/node-module.ts
@@ -28,9 +28,11 @@ export default class NodeModule {
   _remoteData: RemoteData | null;
   _packageJson: PackageJson | null;
   _stats: Stats | null;
+  _path: string | null;
   _realpath: string | null;
   _yarnRequiredBy: Set<string> | null;
   _symlink: string | null;
+  _maxVersionInSameMajor: string | null;
 
   constructor({
     nodeModulesPath,
@@ -48,11 +50,13 @@ export default class NodeModule {
     this.parent = parent;
     this.workspace = workspace;
     this._stats = null;
+    this._path = null;
     this._realpath = null;
     this._remoteData = null;
     this._packageJson = null;
     this._yarnRequiredBy = null;
     this._symlink = null;
+    this._maxVersionInSameMajor = null;
   }
 
   get packageJson(): PackageJson {
@@ -80,7 +84,10 @@ export default class NodeModule {
   }
 
   get path() {
-    return path.join(this.nodeModulesPath, this.name);
+    if (!this._path) {
+      this._path = path.join(this.nodeModulesPath, this.name);
+    }
+    return this._path;
   }
 
   get realpath() {
@@ -143,10 +150,13 @@ export default class NodeModule {
   }
 
   get maxVersionInSameMajor(): string | null {
-    return semverMaxSatisfying(
-      this.remoteData.versions,
-      `^${semver.clean(this.version)}`
-    );
+    if (!this._maxVersionInSameMajor) {
+      this._maxVersionInSameMajor = semverMaxSatisfying(
+        this.remoteData.versions,
+        `^${semver.clean(this.version)}`
+      );
+    }
+    return this._maxVersionInSameMajor;
   }
 
   get maxVersionInSameMajorLastModified(): Date | null {

--- a/src/workspace/workspace.ts
+++ b/src/workspace/workspace.ts
@@ -152,7 +152,7 @@ export default class Workspace {
       }
     }
 
-    return this._isPnpm!;
+    return this._isPnpm;
   }
 
   get resolutionsList(): any {


### PR DESCRIPTION
The `path` getter has 8 references, and the `maxVersionInSameMajor` getter has 3 references:

<img width="642" alt="image" src="https://github.com/ranyitz/qnm/assets/40715044/3ce9ad8d-cd33-4b42-88e3-dbd082fae376">
<img width="618" alt="image" src="https://github.com/ranyitz/qnm/assets/40715044/b96d0b8d-d6ec-4b52-811c-4d03dac1bba6">

The PR prevents `path.join` and `semverMaxSatisfying` from being called multiple times by caching the return value.
