### PR TITLE
fix(node-module): do not throw an error in case of ENOENT error when using realpath

### DIFF
--- a/src/workspace/node-module.ts
+++ b/src/workspace/node-module.ts
@@ -100,7 +100,9 @@ export default class NodeModule {
         // the path when this happen.
         if ('code' in e && e.code === 'ENOENT') {
           this._realpath = this.path;
+          return this.path;
         }
+
         throw e;
       }
     }


### PR DESCRIPTION
This seems like a degradation introduced in https://github.com/ranyitz/qnm/pull/125

In case we have ENOENT, we don't want to throw, rather we prefer to use the known path.

Should Fix #130 